### PR TITLE
fix: drop Node 18 from CI — unblocks all 28 open PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20]
+        node-version: [20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "preflight-dev": "./bin/cli.js"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Problem
ESLint 10 uses `util.styleText` which was introduced in Node 20. Every PR has been failing the `build-and-test (18)` required check, which means **nothing can merge**.

28 open PRs are blocked by this.

## Fix
- CI matrix: `[18, 20]` → `[20, 22]`
- `engines.node`: `>=18` → `>=20`

ESLint 10 explicitly dropped Node 18 support. Node 18 is EOL April 2025 anyway.

**This should be merged first to unblock everything else.**