### PR TITLE
fix(ci): fallback to --ignore-optional when sharp install flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm ci
+      - run: npm ci || npm ci --ignore-optional
       - run: npm run build
       - run: npm run lint
       - run: npm test


### PR DESCRIPTION
## Problem

CI intermittently fails on Node 20 because `sharp` (transitive dep from `@xenova/transformers`) can't download `libvips` — 'socket hang up' errors. This has been causing spurious CI failures on otherwise-green PRs (e.g. #79).

## Fix

Falls back to `npm ci --ignore-optional` if the initial `npm ci` fails. Since preflight only uses `@xenova/transformers` for text embeddings (not image processing), `sharp` is not required at runtime.

## Impact

Should eliminate the most common source of flaky CI failures.