### PR TITLE
feat: add Ollama as local embedding provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "vitest": "^4.0.18"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/src/lib/embeddings.ts
+++ b/src/lib/embeddings.ts
@@ -102,17 +102,75 @@ class OpenAIEmbeddingProvider implements EmbeddingProvider {
   }
 }
 
+// --- Ollama Provider ---
+
+class OllamaEmbeddingProvider implements EmbeddingProvider {
+  dimensions: number;
+  private baseUrl: string;
+  private model: string;
+
+  constructor(options?: { baseUrl?: string; model?: string; dimensions?: number }) {
+    this.baseUrl = (options?.baseUrl ?? "http://localhost:11434").replace(/\/+$/, "");
+    this.model = options?.model ?? "nomic-embed-text";
+    this.dimensions = options?.dimensions ?? 768;
+  }
+
+  async embed(text: string): Promise<number[]> {
+    const processed = preprocessText(text);
+    const resp = await fetch(`${this.baseUrl}/api/embed`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: this.model, input: processed }),
+    });
+
+    if (!resp.ok) {
+      const err = await resp.text();
+      throw new Error(`Ollama embeddings error ${resp.status}: ${err}`);
+    }
+
+    const data = await resp.json();
+    return data.embeddings[0];
+  }
+
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    const processed = texts.map(preprocessText);
+    const resp = await fetch(`${this.baseUrl}/api/embed`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: this.model, input: processed }),
+    });
+
+    if (!resp.ok) {
+      const err = await resp.text();
+      throw new Error(`Ollama embeddings error ${resp.status}: ${err}`);
+    }
+
+    const data = await resp.json();
+    return data.embeddings;
+  }
+}
+
 // --- Factory ---
 
 export interface EmbeddingConfig {
-  provider: "local" | "openai";
+  provider: "local" | "openai" | "ollama";
   apiKey?: string;
+  ollamaBaseUrl?: string;
+  ollamaModel?: string;
+  ollamaDimensions?: number;
 }
 
 export function createEmbeddingProvider(config: EmbeddingConfig): EmbeddingProvider {
   if (config.provider === "openai") {
     if (!config.apiKey) throw new Error("OpenAI API key required for openai embedding provider");
     return new OpenAIEmbeddingProvider(config.apiKey);
+  }
+  if (config.provider === "ollama") {
+    return new OllamaEmbeddingProvider({
+      baseUrl: config.ollamaBaseUrl,
+      model: config.ollamaModel,
+      dimensions: config.ollamaDimensions,
+    });
   }
   return new LocalEmbeddingProvider();
 }

--- a/tests/lib/embeddings.test.ts
+++ b/tests/lib/embeddings.test.ts
@@ -63,4 +63,19 @@ describe("createEmbeddingProvider", () => {
     });
     expect(provider.dimensions).toBe(1536);
   });
+
+  it("returns ollama provider with default 768 dimensions", () => {
+    const provider = createEmbeddingProvider({ provider: "ollama" });
+    expect(provider.dimensions).toBe(768);
+  });
+
+  it("returns ollama provider with custom dimensions", () => {
+    const provider = createEmbeddingProvider({
+      provider: "ollama",
+      ollamaDimensions: 1024,
+      ollamaModel: "mxbai-embed-large",
+      ollamaBaseUrl: "http://myhost:11434",
+    });
+    expect(provider.dimensions).toBe(1024);
+  });
 });


### PR DESCRIPTION
Adds OllamaEmbeddingProvider using Ollama /api/embed endpoint. Fully local, no API key needed. Defaults to nomic-embed-text, 768 dims. Closes #6