### PR TITLE
docs: add .preflight/ example config files with annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,12 @@ This prevents the common failure mode: changing a shared type in one service and
 
 ## Configuration Reference
 
+> **Quick start:** Copy the ready-to-use example configs into your project:
+> ```bash
+> cp -r /path/to/preflight/examples/.preflight .preflight
+> ```
+> Then edit to taste. See [`examples/.preflight/`](examples/.preflight/) for annotated templates.
+
 ### `.preflight/config.yml`
 
 Drop this in your project root. Every field is optional — defaults are sensible.

--- a/examples/.preflight/config.yml
+++ b/examples/.preflight/config.yml
@@ -1,0 +1,34 @@
+# .preflight/config.yml
+# Copy this directory to your project root and customize.
+# All fields are optional — defaults are used for anything you omit.
+
+# Profile controls how aggressively preflight intercepts prompts:
+#   minimal  — only catch the most ambiguous prompts
+#   standard — balanced (default)
+#   full     — check everything, including clear-looking prompts
+profile: standard
+
+# Related projects for cross-service contract awareness.
+# Preflight will extract types, routes, and schemas from these
+# so it can warn you about breaking changes across repos.
+related_projects:
+  # - path: ../api-server
+  #   alias: api
+  # - path: ../shared-types
+  #   alias: types
+
+# Tuning knobs
+thresholds:
+  # Minutes before a session is considered stale (affects context freshness warnings)
+  session_stale_minutes: 30
+  # Tool calls before preflight suggests a checkpoint
+  max_tool_calls_before_checkpoint: 100
+  # How many keyword matches needed to trigger a correction pattern warning
+  correction_pattern_threshold: 3
+
+# Embedding provider for semantic search over session history.
+# "local" uses a built-in model (no API key needed, slower).
+# "openai" uses text-embedding-3-small (faster, requires key).
+embeddings:
+  provider: local
+  # openai_api_key: sk-...  # or set OPENAI_API_KEY env var

--- a/examples/.preflight/triage.yml
+++ b/examples/.preflight/triage.yml
@@ -1,0 +1,47 @@
+# .preflight/triage.yml
+# Customize how the triage engine classifies your prompts.
+# These rules are merged with defaults — you only need to list additions.
+
+# Strictness controls the overall sensitivity:
+#   relaxed  — fewer interruptions, only catches obvious issues
+#   standard — balanced (default)
+#   strict   — catches more edge cases, may over-flag
+strictness: standard
+
+rules:
+  # Prompts containing these keywords are ALWAYS flagged for review,
+  # even if they look clear. Use for high-risk areas of your codebase.
+  always_check:
+    - migration
+    - schema
+    - permissions
+    - billing
+    - rewards
+    # Add your own:
+    # - deployment
+    # - pricing
+    # - auth
+
+  # Prompts matching these are passed through without checks.
+  # Use for routine commands you run constantly.
+  skip:
+    - commit
+    - format
+    - lint
+    - status
+    # Add your own:
+    # - test
+    # - build
+
+  # Keywords that trigger cross-service contract analysis.
+  # When these appear, preflight will check related_projects
+  # for type/route/schema conflicts.
+  cross_service_keywords:
+    - auth
+    - notification
+    - event
+    - webhook
+    # Add your own:
+    # - payment
+    # - user
+    # - api


### PR DESCRIPTION
Adds ready-to-copy example configs in `examples/.preflight/` with detailed comments explaining every option. Updates README Configuration Reference to point to these templates.

Users can now:
```bash
cp -r /path/to/preflight/examples/.preflight .preflight
```

**Files added:**
- `examples/.preflight/config.yml` — profile, related projects, thresholds, embeddings
- `examples/.preflight/triage.yml` — strictness, always_check, skip, cross_service keywords