### PR TITLE
fix: shell syntax bugs in what-changed, checkpoint, session-health

### DIFF
--- a/src/tools/checkpoint.ts
+++ b/src/tools/checkpoint.ts
@@ -63,32 +63,36 @@ ${dirty || "clean"}
         const shortSummary = summary.split("\n")[0].slice(0, 72);
         const commitMsg = `checkpoint: ${shortSummary}`;
 
-        let addCmd: string;
+        let skipAdd = false;
         switch (mode) {
           case "staged": {
             const staged = getStagedFiles();
             if (!staged) {
               commitResult = "nothing staged — skipped commit (use 'tracked' or 'all' mode, or stage files first)";
             }
-            addCmd = "true"; // noop, already staged
+            skipAdd = true; // already staged
             break;
           }
           case "all":
-            addCmd = "git add -A";
-            break;
           case "tracked":
           default:
-            addCmd = "git add -u";
             break;
         }
 
         if (commitResult === "no uncommitted changes") {
           // Stage the checkpoint file too
-          run(`git add "${checkpointFile}"`);
-          const result = run(`${addCmd} && git commit -m "${commitMsg.replace(/"/g, '\\"')}" 2>&1`);
-          if (result.includes("commit failed") || result.includes("nothing to commit")) {
+          run(["add", checkpointFile]);
+          if (!skipAdd) {
+            if (mode === "all") {
+              run(["add", "-A"]);
+            } else {
+              run(["add", "-u"]);
+            }
+          }
+          const result = run(["commit", "-m", commitMsg]);
+          if (result.includes("nothing to commit") || result.startsWith("[command failed")) {
             // Rollback: unstage if commit failed
-            run("git reset HEAD 2>/dev/null");
+            run(["reset", "HEAD"]);
             commitResult = `commit failed: ${result}`;
           } else {
             commitResult = result;

--- a/src/tools/session-health.ts
+++ b/src/tools/session-health.ts
@@ -27,7 +27,8 @@ export function registerSessionHealth(server: McpServer): void {
       const dirtyCount = dirty ? dirty.split("\n").filter(Boolean).length : 0;
       const lastCommit = getLastCommit();
       const lastCommitTimeStr = getLastCommitTime();
-      const uncommittedDiff = run("git diff --stat | tail -1");
+      const diffStatFull = run(["diff", "--stat"]);
+      const uncommittedDiff = diffStatFull.split("\n").pop() || "";
 
       // Parse commit time safely
       const commitDate = parseGitDate(lastCommitTimeStr);

--- a/src/tools/what-changed.ts
+++ b/src/tools/what-changed.ts
@@ -12,8 +12,10 @@ export function registerWhatChanged(server: McpServer): void {
     async ({ since }) => {
       const ref = since || "HEAD~5";
       const diffStat = getDiffStat(ref);
-      const diffFiles = run(`git diff ${ref} --name-only 2>/dev/null || git diff HEAD~3 --name-only`);
-      const log = run(`git log ${ref}..HEAD --oneline 2>/dev/null || git log -5 --oneline`);
+      const diffFilesResult = run(["diff", "--name-only", ref]);
+      const diffFiles = diffFilesResult.startsWith("[") ? run(["diff", "--name-only", "HEAD~3"]) : diffFilesResult;
+      const logResult = run(["log", `${ref}..HEAD`, "--oneline"]);
+      const log = logResult.startsWith("[") ? run(["log", "-5", "--oneline"]) : logResult;
       const branch = getBranch();
 
       const fileList = diffFiles.split("\n").filter(Boolean);


### PR DESCRIPTION
## Bug

`run()` was refactored to use `execFileSync` (no shell), but several tool files still pass shell syntax (`||`, `&&`, `|`, `2>/dev/null`) and prefix `git` in command strings. This causes these tools to silently fail — `execFileSync` passes shell operators as literal git arguments.

## Fixed in this PR

- **what-changed.ts**: Replaced shell `||` fallbacks with JS conditional logic using array args
- **checkpoint.ts**: Split compound `&&` commands into separate `run()` calls with array args  
- **session-health.ts**: Replaced `git diff --stat | tail -1` with array args + JS `.split().pop()`

## Still affected (see #17)

~8 more tool files have the same issue: verify-completion, token-audit, clarify-intent, session-handoff, audit-workspace, enrich-agent-task, scope-work, sequence-tasks.

All tests pass, clean build.