### PR TITLE
feat: smart auto-checkpoint before compaction

### DIFF
--- a/src/lib/checkpoint-writer.ts
+++ b/src/lib/checkpoint-writer.ts
@@ -1,0 +1,106 @@
+import { writeFileSync, existsSync, mkdirSync } from "fs";
+import { join } from "path";
+import { run, getBranch, getStatus, getLastCommit, getStagedFiles } from "./git.js";
+import { PROJECT_DIR } from "./files.js";
+import { appendLog, now } from "./state.js";
+
+export interface CheckpointInput {
+  summary: string;
+  next_steps: string;
+  current_blockers?: string;
+  commit_mode?: "staged" | "tracked" | "all";
+}
+
+export interface CheckpointResult {
+  checkpointFile: string;
+  branch: string;
+  commitMode: string;
+  commitResult: string;
+  timestamp: string;
+}
+
+/**
+ * Write a checkpoint file and optionally commit. Returns structured result.
+ * Shared between the checkpoint tool and auto-checkpoint in session-health.
+ */
+export function writeCheckpoint(input: CheckpointInput): CheckpointResult {
+  const { summary, next_steps, current_blockers } = input;
+  const mode = input.commit_mode || "tracked";
+  const branch = getBranch();
+  const dirty = getStatus();
+  const lastCommit = getLastCommit();
+  const timestamp = now();
+
+  // Ensure checkpoint directory
+  const checkpointDir = join(PROJECT_DIR, ".claude");
+  if (!existsSync(checkpointDir)) mkdirSync(checkpointDir, { recursive: true });
+
+  const checkpointFile = join(checkpointDir, "last-checkpoint.md");
+  const checkpointContent = `# Session Checkpoint
+**Time**: ${timestamp}
+**Branch**: ${branch}
+**Last Commit**: ${lastCommit}
+
+## Accomplished
+${summary}
+
+## Next Steps
+${next_steps}
+
+${current_blockers ? `## Blockers\n${current_blockers}\n` : ""}
+## Uncommitted Work (at checkpoint time)
+\`\`\`
+${dirty || "clean"}
+\`\`\`
+`;
+  writeFileSync(checkpointFile, checkpointContent);
+
+  appendLog("checkpoint-log.jsonl", {
+    timestamp,
+    branch,
+    summary,
+    next_steps,
+    blockers: current_blockers || null,
+    dirty_files: dirty ? dirty.split("\n").filter(Boolean).length : 0,
+    commit_mode: mode,
+  });
+
+  // Commit based on mode
+  let commitResult = "no uncommitted changes";
+  if (dirty) {
+    const shortSummary = summary.split("\n")[0].slice(0, 72);
+    const commitMsg = `checkpoint: ${shortSummary}`;
+
+    let addCmd: string;
+    switch (mode) {
+      case "staged": {
+        const staged = getStagedFiles();
+        if (!staged) {
+          commitResult = "nothing staged — skipped commit (use 'tracked' or 'all' mode, or stage files first)";
+        }
+        addCmd = "true"; // noop, already staged
+        break;
+      }
+      case "all":
+        addCmd = "git add -A";
+        break;
+      case "tracked":
+      default:
+        addCmd = "git add -u";
+        break;
+    }
+
+    if (commitResult === "no uncommitted changes") {
+      run(`git add "${checkpointFile}"`);
+      const result = run(`${addCmd} && git commit -m "${commitMsg.replace(/"/g, '\\"')}" 2>&1`);
+      if (result.includes("commit failed") || result.includes("nothing to commit")) {
+        run("git reset HEAD 2>/dev/null");
+        commitResult = `commit failed: ${result}`;
+      } else {
+        commitResult = result;
+      }
+    }
+  }
+
+  return { checkpointFile: ".claude/last-checkpoint.md", branch, commitMode: mode, commitResult, timestamp };
+}

--- a/src/tools/checkpoint.ts
+++ b/src/tools/checkpoint.ts
@@ -1,10 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { writeFileSync, existsSync, mkdirSync } from "fs";
-import { join, dirname } from "path";
-import { run, getBranch, getStatus, getLastCommit, getStagedFiles } from "../lib/git.js";
-import { PROJECT_DIR } from "../lib/files.js";
-import { appendLog, now } from "../lib/state.js";
+import { writeCheckpoint } from "../lib/checkpoint-writer.js";
 
 export function registerCheckpoint(server: McpServer): void {
   server.tool(
@@ -17,93 +13,16 @@ export function registerCheckpoint(server: McpServer): void {
       commit_mode: z.enum(["staged", "tracked", "all"]).optional().describe("What to commit: 'staged' (only staged files), 'tracked' (modified tracked files), 'all' (git add -A). Default: 'tracked'"),
     },
     async ({ summary, next_steps, current_blockers, commit_mode }) => {
-      const mode = commit_mode || "tracked";
-      const branch = getBranch();
-      const dirty = getStatus();
-      const lastCommit = getLastCommit();
-      const timestamp = now();
-
-      // Write checkpoint file
-      const checkpointDir = join(PROJECT_DIR, ".claude");
-      if (!existsSync(checkpointDir)) mkdirSync(checkpointDir, { recursive: true });
-
-      const checkpointFile = join(checkpointDir, "last-checkpoint.md");
-      const checkpointContent = `# Session Checkpoint
-**Time**: ${timestamp}
-**Branch**: ${branch}
-**Last Commit**: ${lastCommit}
-
-## Accomplished
-${summary}
-
-## Next Steps
-${next_steps}
-
-${current_blockers ? `## Blockers\n${current_blockers}\n` : ""}
-## Uncommitted Work (at checkpoint time)
-\`\`\`
-${dirty || "clean"}
-\`\`\`
-`;
-      writeFileSync(checkpointFile, checkpointContent);
-
-      appendLog("checkpoint-log.jsonl", {
-        timestamp,
-        branch,
-        summary,
-        next_steps,
-        blockers: current_blockers || null,
-        dirty_files: dirty ? dirty.split("\n").filter(Boolean).length : 0,
-        commit_mode: mode,
-      });
-
-      // Commit based on mode
-      let commitResult = "no uncommitted changes";
-      if (dirty) {
-        const shortSummary = summary.split("\n")[0].slice(0, 72);
-        const commitMsg = `checkpoint: ${shortSummary}`;
-
-        let addCmd: string;
-        switch (mode) {
-          case "staged": {
-            const staged = getStagedFiles();
-            if (!staged) {
-              commitResult = "nothing staged — skipped commit (use 'tracked' or 'all' mode, or stage files first)";
-            }
-            addCmd = "true"; // noop, already staged
-            break;
-          }
-          case "all":
-            addCmd = "git add -A";
-            break;
-          case "tracked":
-          default:
-            addCmd = "git add -u";
-            break;
-        }
-
-        if (commitResult === "no uncommitted changes") {
-          // Stage the checkpoint file too
-          run(`git add "${checkpointFile}"`);
-          const result = run(`${addCmd} && git commit -m "${commitMsg.replace(/"/g, '\\"')}" 2>&1`);
-          if (result.includes("commit failed") || result.includes("nothing to commit")) {
-            // Rollback: unstage if commit failed
-            run("git reset HEAD 2>/dev/null");
-            commitResult = `commit failed: ${result}`;
-          } else {
-            commitResult = result;
-          }
-        }
-      }
+      const result = writeCheckpoint({ summary, next_steps, current_blockers, commit_mode });
 
       return {
         content: [{
           type: "text" as const,
           text: `## Checkpoint Saved ✅
-**File**: .claude/last-checkpoint.md
-**Branch**: ${branch}
-**Commit mode**: ${mode}
-**Commit**: ${commitResult}
+**File**: ${result.checkpointFile}
+**Branch**: ${result.branch}
+**Commit mode**: ${result.commitMode}
+**Commit**: ${result.commitResult}
 
 ### What's saved:
 - Summary of work done

--- a/src/tools/session-health.ts
+++ b/src/tools/session-health.ts
@@ -4,6 +4,7 @@ import { getBranch, getStatus, getLastCommit, getLastCommitTime, run } from "../
 import { readIfExists, findWorkspaceDocs } from "../lib/files.js";
 import { loadState, saveState } from "../lib/state.js";
 import { getConfig } from "../lib/config.js";
+import { writeCheckpoint } from "../lib/checkpoint-writer.js";
 
 /** Parse a git date string safely, returning null on failure */
 function parseGitDate(dateStr: string): Date | null {
@@ -18,8 +19,10 @@ export function registerSessionHealth(server: McpServer): void {
     `Check session health and recommend whether to continue, checkpoint, or start fresh. Tracks session depth, uncommitted work, workspace staleness, and time since last commit. Call periodically during long sessions.`,
     {
       stale_threshold_hours: z.number().optional().describe("Hours before a doc is considered stale. Default: 2"),
+      auto_checkpoint: z.boolean().optional().describe("When true, automatically run checkpoint if session health is critical. Default: true"),
     },
-    async ({ stale_threshold_hours }) => {
+    async ({ stale_threshold_hours, auto_checkpoint }) => {
+      const shouldAutoCheckpoint = auto_checkpoint !== false;
       const config = getConfig();
       const staleHours = stale_threshold_hours ?? (config.thresholds.session_stale_minutes / 60);
       const branch = getBranch();
@@ -82,6 +85,26 @@ export function registerSessionHealth(server: McpServer): void {
 
       const commitTimeStr = minutesSinceCommit !== null ? `${minutesSinceCommit}min ago` : "unknown";
 
+      // Auto-checkpoint when critical
+      let autoCheckpointReport = "";
+      if (severity === "critical" && shouldAutoCheckpoint && dirtyCount > 0) {
+        try {
+          const cpResult = writeCheckpoint({
+            summary: `Auto-checkpoint triggered by session-health (session ${sessionMinutes}min, ${dirtyCount} uncommitted files, ${commitTimeStr} since last commit)`,
+            next_steps: "Review .claude/last-checkpoint.md and continue where you left off",
+            commit_mode: "tracked",
+          });
+          autoCheckpointReport = `\n\n### 🛟 Auto-Checkpoint Triggered
+**File**: ${cpResult.checkpointFile}
+**Commit**: ${cpResult.commitResult}
+Work has been automatically saved. Resume with: "Read .claude/last-checkpoint.md"`;
+        } catch (err) {
+          autoCheckpointReport = `\n\n### ⚠️ Auto-Checkpoint Failed
+Error: ${err instanceof Error ? err.message : String(err)}
+Run \`checkpoint\` manually to save your work.`;
+        }
+      }
+
       return {
         content: [{
           type: "text" as const,
@@ -99,7 +122,7 @@ export function registerSessionHealth(server: McpServer): void {
 ${issues.length ? issues.join("\n") : "None — session is healthy"}
 
 ### Recommendation
-${recommendation}`,
+${recommendation}${autoCheckpointReport}`,
         }],
       };
     }


### PR DESCRIPTION
Closes #4

When `check_session_health` detects critical severity (long session, many uncommitted files, stale commits), it now automatically triggers a checkpoint — writes the checkpoint file and commits tracked files.

**Changes:**
- Extract checkpoint logic into shared `lib/checkpoint-writer.ts`
- Refactor `checkpoint` tool to use the shared helper (no behavior change)
- Add `auto_checkpoint` param to `check_session_health` (default: `true`)
- Auto-checkpoint fires when: severity=critical + dirty files exist

Can be disabled per-call with `auto_checkpoint: false`.