### PR TITLE
fix: replace broken shell syntax in run() calls with array args

### DIFF
--- a/src/tools/audit-workspace.ts
+++ b/src/tools/audit-workspace.ts
@@ -36,7 +36,10 @@ export function registerAuditWorkspace(server: McpServer): void {
     {},
     async () => {
       const docs = findWorkspaceDocs();
-      const recentFiles = run("git diff --name-only HEAD~10 2>/dev/null || echo ''").split("\n").filter(Boolean);
+      // run() uses execFileSync — no shell syntax; use array args with fallback
+      let recentFilesRaw = run(["diff", "--name-only", "HEAD~10"]);
+      if (recentFilesRaw.startsWith("[")) recentFilesRaw = "";
+      const recentFiles = recentFilesRaw.split("\n").filter(Boolean);
       const sections: string[] = [];
 
       // Doc freshness
@@ -75,7 +78,10 @@ export function registerAuditWorkspace(server: McpServer): void {
       // Check for gap trackers or similar tracking docs
       const trackingDocs = Object.entries(docs).filter(([n]) => /gap|track|progress/i.test(n));
       if (trackingDocs.length > 0) {
-        const testFilesCount = parseInt(run("find tests -name '*.spec.ts' -o -name '*.test.ts' 2>/dev/null | wc -l").trim()) || 0;
+        // run() only runs git commands; use git ls-files to find test files instead of shell `find`
+        const testFilesList = run(["ls-files", "tests/"]);
+        const testFilesCount = testFilesList.startsWith("[") ? 0
+          : testFilesList.split("\n").filter(f => /\.(spec|test)\.(ts|tsx|js|jsx)$/.test(f)).length;
         sections.push(`## Tracking Docs\n${trackingDocs.map(([n]) => {
           const age = docStatus.find(d => d.name === n)?.ageHours ?? "?";
           return `- .claude/${n} — last updated ${age}h ago`;

--- a/src/tools/checkpoint.ts
+++ b/src/tools/checkpoint.ts
@@ -84,11 +84,14 @@ ${dirty || "clean"}
 
         if (commitResult === "no uncommitted changes") {
           // Stage the checkpoint file too
-          run(`git add "${checkpointFile}"`);
-          const result = run(`${addCmd} && git commit -m "${commitMsg.replace(/"/g, '\\"')}" 2>&1`);
+          run(["add", checkpointFile]);
+          // Stage files based on mode
+          const addArgs = addCmd === "git add -A" ? ["add", "-A"] : ["add", "-u"];
+          run(addArgs);
+          const result = run(["commit", "-m", commitMsg]);
           if (result.includes("commit failed") || result.includes("nothing to commit")) {
             // Rollback: unstage if commit failed
-            run("git reset HEAD 2>/dev/null");
+            run(["reset", "HEAD"]);
             commitResult = `commit failed: ${result}`;
           } else {
             commitResult = result;

--- a/src/tools/session-health.ts
+++ b/src/tools/session-health.ts
@@ -27,7 +27,9 @@ export function registerSessionHealth(server: McpServer): void {
       const dirtyCount = dirty ? dirty.split("\n").filter(Boolean).length : 0;
       const lastCommit = getLastCommit();
       const lastCommitTimeStr = getLastCommitTime();
-      const uncommittedDiff = run("git diff --stat | tail -1");
+      // run() uses execFileSync — shell pipes don't work; get full stat and take the last line
+      const fullDiffStat = run(["diff", "--stat"]);
+      const uncommittedDiff = fullDiffStat.split("\n").filter(Boolean).pop() || "";
 
       // Parse commit time safely
       const commitDate = parseGitDate(lastCommitTimeStr);

--- a/src/tools/sharpen-followup.ts
+++ b/src/tools/sharpen-followup.ts
@@ -26,16 +26,16 @@ function parsePortelainFiles(output: string): string[] {
 
 /** Get recently changed files, safe for first commit / shallow clones */
 function getRecentChangedFiles(): string[] {
-  // Try HEAD~1..HEAD, fall back to just staged, then unstaged
-  const commands = [
-    "git diff --name-only HEAD~1 HEAD 2>/dev/null",
-    "git diff --name-only --cached 2>/dev/null",
-    "git diff --name-only 2>/dev/null",
+  // run() uses execFileSync — no shell syntax; use array args
+  const commands: string[][] = [
+    ["diff", "--name-only", "HEAD~1", "HEAD"],
+    ["diff", "--name-only", "--cached"],
+    ["diff", "--name-only"],
   ];
   const results = new Set<string>();
-  for (const cmd of commands) {
-    const out = run(cmd);
-    if (out) out.split("\n").filter(Boolean).forEach((f) => results.add(f));
+  for (const args of commands) {
+    const out = run(args);
+    if (out && !out.startsWith("[")) out.split("\n").filter(Boolean).forEach((f) => results.add(f));
     if (results.size > 0) break; // first successful source is enough
   }
   return [...results];
@@ -87,7 +87,7 @@ export function registerSharpenFollowup(server: McpServer): void {
       // Gather context to resolve ambiguity
       const contextFiles: string[] = [...(previous_files ?? [])];
       const recentChanged = getRecentChangedFiles();
-      const porcelainOutput = run("git status --porcelain 2>/dev/null");
+      const porcelainOutput = run(["status", "--porcelain"]);
       const untrackedOrModified = parsePortelainFiles(porcelainOutput);
 
       const allKnownFiles = [...new Set([...contextFiles, ...recentChanged, ...untrackedOrModified])].filter(Boolean);

--- a/src/tools/what-changed.ts
+++ b/src/tools/what-changed.ts
@@ -12,8 +12,14 @@ export function registerWhatChanged(server: McpServer): void {
     async ({ since }) => {
       const ref = since || "HEAD~5";
       const diffStat = getDiffStat(ref);
-      const diffFiles = run(`git diff ${ref} --name-only 2>/dev/null || git diff HEAD~3 --name-only`);
-      const log = run(`git log ${ref}..HEAD --oneline 2>/dev/null || git log -5 --oneline`);
+
+      // Use array args — run() uses execFileSync, shell operators don't work
+      let diffFiles = run(["diff", "--name-only", ref]);
+      if (diffFiles.startsWith("[")) diffFiles = run(["diff", "--name-only", "HEAD~3"]);
+
+      let log = run(["log", `${ref}..HEAD`, "--oneline"]);
+      if (log.startsWith("[")) log = run(["log", "-5", "--oneline"]);
+
       const branch = getBranch();
 
       const fileList = diffFiles.split("\n").filter(Boolean);


### PR DESCRIPTION
## Problem

`run()` in `lib/git.ts` uses `execFileSync` (no shell), but 5 tools were passing shell operators (`2>/dev/null`, `||`, `|`, `&&`) as string args. These got split on whitespace and passed as literal git arguments, silently breaking fallback/pipe logic.

For example, `what-changed.ts` had:
```ts
run(`git diff ${ref} --name-only 2>/dev/null || git diff HEAD~3 --name-only`)
```
This became `execFileSync('git', ['diff', ref, '--name-only', '2>/dev/null', '||', 'git', 'diff', 'HEAD~3', '--name-only'])` — git would error or silently ignore the junk args.

## Fix

Replaced all broken calls with proper array args and explicit JS fallback logic:
- **what-changed.ts** — diff/log fallbacks
- **session-health.ts** — `diff --stat | tail -1` → array + JS `.pop()`
- **audit-workspace.ts** — diff fallback + replaced `find | wc` with `git ls-files`
- **sharpen-followup.ts** — 3 diff commands + status
- **checkpoint.ts** — add/commit/reset chain

All 43 tests pass. Build clean.