### PR TITLE
feat: add Ollama embedding provider

### DIFF
--- a/src/lib/embeddings.ts
+++ b/src/lib/embeddings.ts
@@ -102,17 +102,76 @@ class OpenAIEmbeddingProvider implements EmbeddingProvider {
   }
 }
 
+// --- Ollama Provider ---
+
+class OllamaEmbeddingProvider implements EmbeddingProvider {
+  dimensions: number;
+  private baseUrl: string;
+  private model: string;
+
+  constructor(options?: { baseUrl?: string; model?: string; dimensions?: number }) {
+    this.baseUrl = (options?.baseUrl ?? "http://localhost:11434").replace(/\/+$/, "");
+    this.model = options?.model ?? "nomic-embed-text";
+    this.dimensions = options?.dimensions ?? 768;
+  }
+
+  async embed(text: string): Promise<number[]> {
+    const processed = preprocessText(text);
+    const resp = await fetch(`${this.baseUrl}/api/embed`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: this.model, input: processed }),
+    });
+
+    if (!resp.ok) {
+      const err = await resp.text();
+      throw new Error(`Ollama embeddings API error ${resp.status}: ${err}`);
+    }
+
+    const data = await resp.json();
+    // Ollama /api/embed returns { embeddings: number[][] }
+    return data.embeddings[0];
+  }
+
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    const processed = texts.map(preprocessText);
+    const resp = await fetch(`${this.baseUrl}/api/embed`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: this.model, input: processed }),
+    });
+
+    if (!resp.ok) {
+      const err = await resp.text();
+      throw new Error(`Ollama embeddings API error ${resp.status}: ${err}`);
+    }
+
+    const data = await resp.json();
+    return data.embeddings;
+  }
+}
+
 // --- Factory ---
 
 export interface EmbeddingConfig {
-  provider: "local" | "openai";
+  provider: "local" | "openai" | "ollama";
   apiKey?: string;
+  ollamaBaseUrl?: string;
+  ollamaModel?: string;
+  ollamaDimensions?: number;
 }
 
 export function createEmbeddingProvider(config: EmbeddingConfig): EmbeddingProvider {
   if (config.provider === "openai") {
     if (!config.apiKey) throw new Error("OpenAI API key required for openai embedding provider");
     return new OpenAIEmbeddingProvider(config.apiKey);
+  }
+  if (config.provider === "ollama") {
+    return new OllamaEmbeddingProvider({
+      baseUrl: config.ollamaBaseUrl,
+      model: config.ollamaModel,
+      dimensions: config.ollamaDimensions,
+    });
   }
   return new LocalEmbeddingProvider();
 }

--- a/tests/lib/embeddings.test.ts
+++ b/tests/lib/embeddings.test.ts
@@ -63,4 +63,27 @@ describe("createEmbeddingProvider", () => {
     });
     expect(provider.dimensions).toBe(1536);
   });
+
+  it("returns ollama provider with default 768 dimensions", () => {
+    const provider = createEmbeddingProvider({ provider: "ollama" });
+    expect(provider.dimensions).toBe(768);
+  });
+
+  it("returns ollama provider with custom dimensions", () => {
+    const provider = createEmbeddingProvider({
+      provider: "ollama",
+      ollamaDimensions: 1024,
+    });
+    expect(provider.dimensions).toBe(1024);
+  });
+
+  it("ollama provider has embed and embedBatch methods", () => {
+    const provider = createEmbeddingProvider({
+      provider: "ollama",
+      ollamaBaseUrl: "http://localhost:11434",
+      ollamaModel: "nomic-embed-text",
+    });
+    expect(typeof provider.embed).toBe("function");
+    expect(typeof provider.embedBatch).toBe("function");
+  });
 });


### PR DESCRIPTION
Adds Ollama as a local embedding provider (closes #6).

- New `OllamaEmbeddingProvider` class calling `/api/embed` endpoint
- Defaults: `nomic-embed-text` model, 768 dimensions, `localhost:11434`
- Configurable via `ollamaBaseUrl`, `ollamaModel`, `ollamaDimensions`
- Batch support via Ollama's native multi-input endpoint
- 3 new unit tests, all 46 passing

No external dependencies added — uses native `fetch`.