### PR TITLE
fix: validate config enum values from YAML + add 13 config tests

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -63,7 +63,16 @@ const DEFAULT_CONFIG: PreflightConfig = {
   },
 };
 
+const VALID_PROFILES: Profile[] = ["minimal", "standard", "full"];
+const VALID_PROVIDERS: EmbeddingProvider[] = ["local", "openai"];
+const VALID_STRICTNESS: TriageStrictness[] = ["relaxed", "standard", "strict"];
+
 let _config: PreflightConfig | null = null;
+
+/** Reset cached config (useful for testing). */
+export function resetConfig(): void {
+  _config = null;
+}
 
 /** Load config from .preflight/ directory or fall back to env vars */
 function loadConfig(): PreflightConfig {
@@ -81,11 +90,23 @@ function loadConfig(): PreflightConfig {
       const configData = yamlLoad(configYaml) as any;
       
       if (configData) {
-        // Merge config data with defaults
-        if (configData.profile) config.profile = configData.profile;
+        // Merge config data with defaults (validate enum values)
+        if (configData.profile) {
+          if (VALID_PROFILES.includes(configData.profile)) {
+            config.profile = configData.profile;
+          } else {
+            console.warn(`preflight: warning - invalid profile "${configData.profile}", using "${config.profile}"`);
+          }
+        }
         if (configData.related_projects) config.related_projects = configData.related_projects;
         if (configData.thresholds) config.thresholds = { ...config.thresholds, ...configData.thresholds };
-        if (configData.embeddings) config.embeddings = { ...config.embeddings, ...configData.embeddings };
+        if (configData.embeddings) {
+          if (configData.embeddings.provider && !VALID_PROVIDERS.includes(configData.embeddings.provider)) {
+            console.warn(`preflight: warning - invalid embedding provider "${configData.embeddings.provider}", using "${config.embeddings.provider}"`);
+            delete configData.embeddings.provider;
+          }
+          config.embeddings = { ...config.embeddings, ...configData.embeddings };
+        }
       }
     } catch (error) {
       console.warn(`preflight: warning - failed to parse .preflight/config.yml: ${error}`);
@@ -100,7 +121,13 @@ function loadConfig(): PreflightConfig {
       
       if (triageData) {
         if (triageData.rules) config.triage.rules = { ...config.triage.rules, ...triageData.rules };
-        if (triageData.strictness) config.triage.strictness = triageData.strictness;
+        if (triageData.strictness) {
+          if (VALID_STRICTNESS.includes(triageData.strictness)) {
+            config.triage.strictness = triageData.strictness;
+          } else {
+            console.warn(`preflight: warning - invalid triage strictness "${triageData.strictness}", using "${config.triage.strictness}"`);
+          }
+        }
       }
     } catch (error) {
       console.warn(`preflight: warning - failed to parse .preflight/triage.yml: ${error}`);

--- a/tests/lib/config.test.ts
+++ b/tests/lib/config.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// We need to mock fs and files before importing config
+vi.mock("fs", async () => {
+  const actual = await vi.importActual<typeof import("fs")>("fs");
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    readFileSync: vi.fn(),
+  };
+});
+
+vi.mock("../../src/lib/files.js", () => ({
+  PROJECT_DIR: "/fake/project",
+}));
+
+import { existsSync, readFileSync } from "fs";
+import { getConfig, resetConfig, hasPreflightConfig, getRelatedProjects } from "../../src/lib/config.js";
+
+const mockExists = existsSync as ReturnType<typeof vi.fn>;
+const mockRead = readFileSync as ReturnType<typeof vi.fn>;
+
+describe("config", () => {
+  beforeEach(() => {
+    resetConfig();
+    mockExists.mockReset();
+    mockRead.mockReset();
+    // Default: no .preflight dir
+    mockExists.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    // Clean env vars
+    delete process.env.PROMPT_DISCIPLINE_PROFILE;
+    delete process.env.PREFLIGHT_RELATED;
+    delete process.env.EMBEDDING_PROVIDER;
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  it("returns defaults when no config exists", () => {
+    const cfg = getConfig();
+    expect(cfg.profile).toBe("standard");
+    expect(cfg.embeddings.provider).toBe("local");
+    expect(cfg.triage.strictness).toBe("standard");
+    expect(cfg.related_projects).toEqual([]);
+  });
+
+  it("reads env vars when no .preflight dir", () => {
+    process.env.PROMPT_DISCIPLINE_PROFILE = "minimal";
+    process.env.EMBEDDING_PROVIDER = "openai";
+    process.env.OPENAI_API_KEY = "sk-test";
+    const cfg = getConfig();
+    expect(cfg.profile).toBe("minimal");
+    expect(cfg.embeddings.provider).toBe("openai");
+    expect(cfg.embeddings.openai_api_key).toBe("sk-test");
+  });
+
+  it("ignores invalid env profile values", () => {
+    process.env.PROMPT_DISCIPLINE_PROFILE = "turbo";
+    const cfg = getConfig();
+    expect(cfg.profile).toBe("standard");
+  });
+
+  it("parses PREFLIGHT_RELATED env var", () => {
+    process.env.PREFLIGHT_RELATED = "/a/b, /c/d";
+    const cfg = getConfig();
+    expect(cfg.related_projects).toEqual([
+      { path: "/a/b", alias: "b" },
+      { path: "/c/d", alias: "d" },
+    ]);
+    expect(getRelatedProjects()).toEqual(["/a/b", "/c/d"]);
+  });
+
+  it("loads config.yml and validates profile", () => {
+    mockExists.mockImplementation((p: any) => {
+      const s = String(p);
+      return s.endsWith(".preflight") || s.endsWith("config.yml");
+    });
+    mockRead.mockReturnValue('profile: "full"\n');
+
+    const cfg = getConfig();
+    expect(cfg.profile).toBe("full");
+  });
+
+  it("warns and ignores invalid profile from YAML", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockExists.mockImplementation((p: any) => {
+      const s = String(p);
+      return s.endsWith(".preflight") || s.endsWith("config.yml");
+    });
+    mockRead.mockReturnValue('profile: "turbo"\n');
+
+    const cfg = getConfig();
+    expect(cfg.profile).toBe("standard"); // fallback
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("invalid profile"));
+    warnSpy.mockRestore();
+  });
+
+  it("warns and ignores invalid embedding provider from YAML", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockExists.mockImplementation((p: any) => {
+      const s = String(p);
+      return s.endsWith(".preflight") || s.endsWith("config.yml");
+    });
+    mockRead.mockReturnValue('embeddings:\n  provider: "ollama"\n');
+
+    const cfg = getConfig();
+    expect(cfg.embeddings.provider).toBe("local"); // fallback
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("invalid embedding provider"));
+    warnSpy.mockRestore();
+  });
+
+  it("warns and ignores invalid triage strictness from YAML", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockExists.mockImplementation((p: any) => {
+      const s = String(p);
+      return s.endsWith(".preflight") || s.endsWith("triage.yml");
+    });
+    mockRead.mockReturnValue('strictness: "extreme"\n');
+
+    const cfg = getConfig();
+    expect(cfg.triage.strictness).toBe("standard"); // fallback
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("invalid triage strictness"));
+    warnSpy.mockRestore();
+  });
+
+  it("caches config on second call", () => {
+    const cfg1 = getConfig();
+    const cfg2 = getConfig();
+    expect(cfg1).toBe(cfg2); // same reference
+  });
+
+  it("resetConfig clears cache", () => {
+    const cfg1 = getConfig();
+    resetConfig();
+    const cfg2 = getConfig();
+    expect(cfg1).not.toBe(cfg2);
+    expect(cfg1).toEqual(cfg2);
+  });
+
+  it("hasPreflightConfig returns false when dir missing", () => {
+    expect(hasPreflightConfig()).toBe(false);
+  });
+
+  it("hasPreflightConfig returns true when dir exists", () => {
+    mockExists.mockImplementation((p: any) => String(p).endsWith(".preflight"));
+    expect(hasPreflightConfig()).toBe(true);
+  });
+
+  it("handles malformed YAML gracefully", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockExists.mockImplementation((p: any) => {
+      const s = String(p);
+      return s.endsWith(".preflight") || s.endsWith("config.yml");
+    });
+    mockRead.mockImplementation(() => { throw new Error("read error"); });
+
+    const cfg = getConfig();
+    expect(cfg.profile).toBe("standard"); // defaults
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
**Problem:** Config values from `.preflight/config.yml` and `triage.yml` were accepted without validation — setting `profile: "turbo"` or `strictness: "extreme"` would silently corrupt config state.

**Fix:**
- Validate `profile`, `embeddings.provider`, and `triage.strictness` against allowed enums
- Invalid values log a warning and fall back to defaults
- Export `resetConfig()` for test isolation

**Tests:** 13 new unit tests covering defaults, env vars, YAML loading, validation warnings, caching, and error handling. All 56 tests pass.