### PR TITLE
fix: broken shell syntax in git.run() calls (checkpoint, what-changed, session-health)

### DIFF
--- a/src/tools/checkpoint.ts
+++ b/src/tools/checkpoint.ts
@@ -84,11 +84,16 @@ ${dirty || "clean"}
 
         if (commitResult === "no uncommitted changes") {
           // Stage the checkpoint file too
-          run(`git add "${checkpointFile}"`);
-          const result = run(`${addCmd} && git commit -m "${commitMsg.replace(/"/g, '\\"')}" 2>&1`);
+          run(["add", checkpointFile]);
+          if (addCmd !== "true") {
+            // Run the staging command (e.g. "add -u" or "add -A")
+            const addArgs = addCmd.replace(/^git\s+/, "").split(/\s+/);
+            run(addArgs);
+          }
+          const result = run(["commit", "-m", commitMsg]);
           if (result.includes("commit failed") || result.includes("nothing to commit")) {
             // Rollback: unstage if commit failed
-            run("git reset HEAD 2>/dev/null");
+            run(["reset", "HEAD"]);
             commitResult = `commit failed: ${result}`;
           } else {
             commitResult = result;

--- a/src/tools/session-health.ts
+++ b/src/tools/session-health.ts
@@ -27,7 +27,8 @@ export function registerSessionHealth(server: McpServer): void {
       const dirtyCount = dirty ? dirty.split("\n").filter(Boolean).length : 0;
       const lastCommit = getLastCommit();
       const lastCommitTimeStr = getLastCommitTime();
-      const uncommittedDiff = run("git diff --stat | tail -1");
+      const fullDiffStat = run(["diff", "--stat"]);
+      const uncommittedDiff = fullDiffStat.split("\n").filter(Boolean).pop() || "";
 
       // Parse commit time safely
       const commitDate = parseGitDate(lastCommitTimeStr);

--- a/src/tools/what-changed.ts
+++ b/src/tools/what-changed.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { run, getBranch, getDiffStat } from "../lib/git.js";
+import { run, getBranch, getDiffStat, getDiffFiles } from "../lib/git.js";
 
 export function registerWhatChanged(server: McpServer): void {
   server.tool(
@@ -12,8 +12,9 @@ export function registerWhatChanged(server: McpServer): void {
     async ({ since }) => {
       const ref = since || "HEAD~5";
       const diffStat = getDiffStat(ref);
-      const diffFiles = run(`git diff ${ref} --name-only 2>/dev/null || git diff HEAD~3 --name-only`);
-      const log = run(`git log ${ref}..HEAD --oneline 2>/dev/null || git log -5 --oneline`);
+      const diffFiles = getDiffFiles(ref);
+      const logResult = run(["log", `${ref}..HEAD`, "--oneline"]);
+      const log = logResult.startsWith("[") ? run(["log", "-5", "--oneline"]) : logResult;
       const branch = getBranch();
 
       const fileList = diffFiles.split("\n").filter(Boolean);


### PR DESCRIPTION
## Problem

`run()` in `lib/git.ts` uses `execFileSync` which does **not** interpret shell operators (`|`, `||`, `&&`, `2>/dev/null`). Multiple tools were passing shell pipelines and redirects as if they were shell commands, causing silent failures.

Same bug class as #170 (clarify-intent).

## Fixed in this PR

- **what-changed.ts**: Used `getDiffFiles()` helper + array args for `git log`
- **checkpoint.ts**: Array args for `add`/`commit`/`reset` instead of shell chains  
- **session-health.ts**: Array args for `diff --stat`, split output in JS instead of piping to `tail -1`

## Still affected (tracked in separate issue)

verify-completion, token-audit, session-handoff, audit-workspace, sharpen-followup, scope-work, enrich-agent-task, sequence-tasks — all have the same pattern.

## Testing

- `pnpm tsc --noEmit` clean
- All 43 tests pass