### PR TITLE
fix: add Ollama embedding provider, fix broken build

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,8 @@ Manual contract definitions that supplement auto-extraction:
 
 Environment variables are **fallbacks** — `.preflight/` config takes precedence when present.
 
+> 💡 **Ready-to-use examples:** Copy [`examples/.preflight/`](examples/.preflight/) into your project root for a working starter config with detailed comments.
+
 ---
 
 ## Embedding Providers

--- a/README.md
+++ b/README.md
@@ -564,6 +564,95 @@ flowchart TB
 
 ---
 
+## Troubleshooting
+
+### "Cannot find module 'vectordb'" or LanceDB import errors
+
+LanceDB uses native binaries. If you see module resolution errors:
+
+```bash
+# Clean install with native deps rebuilt
+rm -rf node_modules package-lock.json
+npm install
+
+# If still failing, check your Node version (20+ required)
+node --version
+```
+
+On Apple Silicon Macs, make sure you're running a native arm64 Node — not Rosetta. Check with `node -e "console.log(process.arch)"` (should print `arm64`).
+
+### First run is slow (~90MB model download)
+
+The local embedding provider ([Xenova/all-MiniLM-L6-v2](https://huggingface.co/Xenova/all-MiniLM-L6-v2)) downloads a ~90MB model on first use. This is a one-time cost — subsequent runs use the cached model. If the download hangs behind a corporate proxy, switch to OpenAI embeddings:
+
+```bash
+export OPENAI_API_KEY=sk-...
+export EMBEDDING_PROVIDER=openai
+```
+
+### "OpenAI API key required for openai embedding provider"
+
+You set `EMBEDDING_PROVIDER=openai` (or `embeddings.provider: openai` in `.preflight/config.yml`) but didn't provide a key. Either:
+
+- Set `OPENAI_API_KEY` in your environment, or
+- Switch back to local: `export EMBEDDING_PROVIDER=local`
+
+### Tools not showing up in Claude Code
+
+1. Make sure the MCP server is registered. Run `claude mcp list` — you should see `preflight`.
+2. If missing, re-add it:
+   ```bash
+   claude mcp add preflight -- npx tsx /path/to/preflight/src/index.ts
+   ```
+3. Restart Claude Code after adding.
+
+### `CLAUDE_PROJECT_DIR` not set
+
+Some tools (onboarding, session search, contracts) need to know your project root. If they return empty results:
+
+```bash
+claude mcp add preflight \
+  -e CLAUDE_PROJECT_DIR=/path/to/your/project \
+  -- npx tsx /path/to/preflight/src/index.ts
+```
+
+Or set it globally: `export CLAUDE_PROJECT_DIR=/path/to/your/project`
+
+### `.preflight/config.yml` parse errors
+
+If you see `warning - failed to parse .preflight/config.yml`, your YAML is malformed. Common issues:
+
+- Tabs instead of spaces (YAML requires spaces)
+- Missing quotes around values with special characters
+- Incorrect indentation under `related_projects`
+
+Validate with: `npx yaml-lint .preflight/config.yml` or paste into [yamllint.com](https://www.yamllint.com/).
+
+### No session data found during onboarding
+
+`onboard_project` looks for JSONL files in `~/.claude/projects/<encoded-path>/`. If nothing is found:
+
+- Make sure you've actually used Claude Code on the project (at least one session)
+- Check that `CLAUDE_PROJECT_DIR` matches the exact path Claude Code was opened in
+- The path encoding is URL-style — `/Users/jack/my-app` becomes `%2FUsers%2Fjack%2Fmy-app`
+
+### Ollama embeddings connection refused
+
+If using Ollama as your embedding provider and getting connection errors:
+
+```bash
+# Make sure Ollama is running
+ollama serve
+
+# Pull the embedding model
+ollama pull all-minilm
+
+# Verify it works
+curl http://localhost:11434/api/embed -d '{"model":"all-minilm","input":"test"}'
+```
+
+---
+
 ## Contributing
 
 This project is young and there's plenty to do. Check the [issues](https://github.com/TerminalGravity/preflight/issues) — several are tagged `good first issue`.

--- a/examples/.preflight/config.yml
+++ b/examples/.preflight/config.yml
@@ -1,0 +1,35 @@
+# .preflight/config.yml — Drop this in your project root
+#
+# This is an example config for a typical Next.js + microservices setup.
+# Every field is optional — preflight works with sensible defaults out of the box.
+# Commit this to your repo so the whole team gets the same preflight behavior.
+
+# Profile controls how much detail preflight returns.
+#   "minimal"  — only flags ambiguous+ prompts, skips clarification detail
+#   "standard" — balanced (default)
+#   "full"     — maximum detail on every non-trivial prompt
+profile: standard
+
+# Related projects for cross-service awareness.
+# Preflight will search these for shared types, routes, and contracts
+# so it can warn you when a change might break a consumer.
+related_projects:
+  - path: /Users/you/code/auth-service
+    alias: auth
+  - path: /Users/you/code/billing-api
+    alias: billing
+  - path: /Users/you/code/shared-types
+    alias: types
+
+# Behavioral thresholds — tune these to your workflow
+thresholds:
+  session_stale_minutes: 30                # Warn if no activity for this long
+  max_tool_calls_before_checkpoint: 100    # Suggest a checkpoint after N tool calls
+  correction_pattern_threshold: 3          # Min corrections before flagging a pattern
+
+# Embedding provider for semantic search over session history.
+# "local" uses Xenova transformers (no API key needed, runs on CPU).
+# "openai" uses text-embedding-3-small (faster, needs OPENAI_API_KEY).
+embeddings:
+  provider: local
+  # openai_api_key: sk-...               # Uncomment if using openai provider

--- a/examples/.preflight/contracts/api.yml
+++ b/examples/.preflight/contracts/api.yml
@@ -1,0 +1,58 @@
+# .preflight/contracts/api.yml — Manual contract definitions
+#
+# Define shared types and interfaces that preflight should know about.
+# These supplement auto-extracted contracts from your codebase.
+# Manual definitions win on name conflicts with auto-extracted ones.
+#
+# Why manual contracts?
+#   - Document cross-service interfaces that live in docs, not code
+#   - Define contracts for external APIs your services consume
+#   - Pin down types that are implicit (e.g., event payloads)
+
+- name: User
+  kind: interface
+  description: Core user model shared across all services
+  fields:
+    - name: id
+      type: string
+      required: true
+    - name: email
+      type: string
+      required: true
+    - name: tier
+      type: "'free' | 'pro' | 'enterprise'"
+      required: true
+    - name: createdAt
+      type: Date
+      required: true
+
+- name: AuthToken
+  kind: interface
+  description: JWT payload structure from auth-service
+  fields:
+    - name: userId
+      type: string
+      required: true
+    - name: permissions
+      type: string[]
+      required: true
+    - name: expiresAt
+      type: number
+      required: true
+
+- name: WebhookPayload
+  kind: interface
+  description: Standard webhook envelope for inter-service events
+  fields:
+    - name: event
+      type: string
+      required: true
+    - name: timestamp
+      type: string
+      required: true
+    - name: data
+      type: Record<string, unknown>
+      required: true
+    - name: source
+      type: string
+      required: true

--- a/examples/.preflight/triage.yml
+++ b/examples/.preflight/triage.yml
@@ -1,0 +1,45 @@
+# .preflight/triage.yml — Controls how preflight classifies your prompts
+#
+# The triage engine routes prompts into categories:
+#   TRIVIAL       → pass through (commit, format, lint)
+#   CLEAR         → well-specified, no intervention needed
+#   AMBIGUOUS     → needs clarification before proceeding
+#   MULTI-STEP    → complex task, preflight suggests a plan
+#   CROSS-SERVICE → touches multiple projects, pulls in contracts
+#
+# Customize the keywords below to match your domain.
+
+rules:
+  # Prompts containing these words are always flagged as AMBIGUOUS.
+  # Add domain-specific terms that tend to produce vague prompts.
+  always_check:
+    - rewards
+    - permissions
+    - migration
+    - schema
+    - pricing          # example: your billing domain
+    - onboarding       # example: multi-step user flows
+
+  # Prompts containing these words skip checks entirely (TRIVIAL).
+  # These are safe, mechanical tasks that don't need guardrails.
+  skip:
+    - commit
+    - format
+    - lint
+    - prettier
+    - "git push"
+
+  # Prompts containing these words trigger CROSS-SERVICE classification.
+  # Preflight will search related_projects for relevant types and routes.
+  cross_service_keywords:
+    - auth
+    - notification
+    - event
+    - webhook
+    - billing          # matches the related_project alias
+
+# How aggressively to classify prompts.
+#   "relaxed"  — more prompts pass as clear (experienced users)
+#   "standard" — balanced (default)
+#   "strict"   — more prompts flagged as ambiguous (new teams, complex codebases)
+strictness: standard

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,35 @@
+# Examples
+
+## `.preflight/` Config Directory
+
+The `.preflight/` directory contains example configuration files you can copy into your project root:
+
+```
+.preflight/
+├── config.yml              # Main config — profile, related projects, thresholds
+├── triage.yml              # Triage rules — keywords, strictness
+└── contracts/
+    └── api.yml             # Manual contract definitions for cross-service types
+```
+
+### Quick setup
+
+```bash
+# From your project root:
+cp -r /path/to/preflight/examples/.preflight .preflight
+
+# Edit paths in config.yml to match your setup:
+$EDITOR .preflight/config.yml
+```
+
+Then commit `.preflight/` to your repo — your whole team gets the same preflight behavior.
+
+### What each file does
+
+| File | Purpose | Required? |
+|------|---------|-----------|
+| `config.yml` | Profile, related projects, thresholds, embedding config | No — sensible defaults |
+| `triage.yml` | Keyword rules for prompt classification | No — sensible defaults |
+| `contracts/*.yml` | Manual type/interface definitions for cross-service awareness | No — auto-extraction works without it |
+
+All files are optional. Preflight works out of the box with zero config — these files let you tune it to your codebase.

--- a/src/lib/embeddings.ts
+++ b/src/lib/embeddings.ts
@@ -102,17 +102,77 @@ class OpenAIEmbeddingProvider implements EmbeddingProvider {
   }
 }
 
+// --- Ollama Provider ---
+
+class OllamaEmbeddingProvider implements EmbeddingProvider {
+  dimensions: number;
+  private baseUrl: string;
+  private model: string;
+
+  constructor(opts?: { baseUrl?: string; model?: string; dimensions?: number }) {
+    this.baseUrl = (opts?.baseUrl ?? "http://localhost:11434").replace(/\/+$/, "");
+    this.model = opts?.model ?? "nomic-embed-text";
+    // Default dimensions for nomic-embed-text; override if using a different model
+    this.dimensions = opts?.dimensions ?? 768;
+  }
+
+  async embed(text: string): Promise<number[]> {
+    const processed = preprocessText(text);
+    const resp = await fetch(`${this.baseUrl}/api/embed`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: this.model, input: processed }),
+    });
+
+    if (!resp.ok) {
+      const err = await resp.text();
+      throw new Error(`Ollama embed API error ${resp.status}: ${err}`);
+    }
+
+    const data = await resp.json();
+    return data.embeddings[0];
+  }
+
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    const processed = texts.map(preprocessText);
+    const resp = await fetch(`${this.baseUrl}/api/embed`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: this.model, input: processed }),
+    });
+
+    if (!resp.ok) {
+      const err = await resp.text();
+      throw new Error(`Ollama embed API error ${resp.status}: ${err}`);
+    }
+
+    const data = await resp.json();
+    return data.embeddings;
+  }
+}
+
 // --- Factory ---
 
-export interface EmbeddingConfig {
-  provider: "local" | "openai";
-  apiKey?: string;
+export interface OllamaEmbeddingConfig {
+  provider: "ollama";
+  baseUrl?: string;
+  model?: string;
+  dimensions?: number;
 }
+
+export type EmbeddingConfig =
+  | { provider: "local" }
+  | { provider: "openai"; apiKey: string }
+  | OllamaEmbeddingConfig;
 
 export function createEmbeddingProvider(config: EmbeddingConfig): EmbeddingProvider {
   if (config.provider === "openai") {
-    if (!config.apiKey) throw new Error("OpenAI API key required for openai embedding provider");
+    if (!("apiKey" in config) || !config.apiKey)
+      throw new Error("OpenAI API key required for openai embedding provider");
     return new OpenAIEmbeddingProvider(config.apiKey);
+  }
+  if (config.provider === "ollama") {
+    return new OllamaEmbeddingProvider(config);
   }
   return new LocalEmbeddingProvider();
 }

--- a/src/lib/timeline-db.ts
+++ b/src/lib/timeline-db.ts
@@ -55,9 +55,11 @@ export interface ProjectInfo {
 }
 
 export interface TimelineConfig {
-  embedding_provider: "local" | "openai";
+  embedding_provider: "local" | "openai" | "ollama";
   embedding_model: string;
   openai_api_key?: string;
+  ollama_base_url?: string;
+  ollama_model?: string;
   indexed_projects: Record<string, {
     last_session_index: string;
     last_git_index: string;
@@ -183,10 +185,13 @@ export async function getDb(projectDir: string): Promise<lancedb.Connection> {
 async function getEmbedder(): Promise<EmbeddingProvider> {
   if (!_embedder) {
     const config = await loadConfig();
-    _embedder = createEmbeddingProvider({
-      provider: config.embedding_provider,
-      apiKey: config.openai_api_key,
-    });
+    const embeddingConfig: EmbeddingConfig =
+      config.embedding_provider === "openai"
+        ? { provider: "openai", apiKey: config.openai_api_key! }
+        : config.embedding_provider === "ollama"
+          ? { provider: "ollama", baseUrl: config.ollama_base_url, model: config.ollama_model }
+          : { provider: "local" };
+    _embedder = createEmbeddingProvider(embeddingConfig);
   }
   return _embedder;
 }

--- a/src/tools/onboard-project.ts
+++ b/src/tools/onboard-project.ts
@@ -30,7 +30,7 @@ export function registerOnboardProject(server: McpServer) {
     "Index a project's Claude Code sessions and git history into the timeline database for semantic search and chronological viewing.",
     {
       project_dir: z.string().describe("Absolute path to the project directory"),
-      embedding_provider: z.enum(["local", "openai"]).default("local"),
+      embedding_provider: z.enum(["local", "openai", "ollama"]).default("local"),
       openai_api_key: z.string().optional(),
       git_depth: z.enum(["all", "6months", "1year", "3months"]).default("all"),
       git_since: z.string().optional().describe("Override git_depth with exact start date (ISO: '2025-08-01')"),
@@ -171,10 +171,13 @@ export function registerOnboardProject(server: McpServer) {
       }
 
       // 6. Embed all events in batches
-      const embedder = createEmbeddingProvider({
-        provider: embedding_provider,
-        apiKey: openai_api_key,
-      });
+      const embeddingConfig: import("../lib/embeddings.js").EmbeddingConfig =
+        embedding_provider === "openai"
+          ? { provider: "openai", apiKey: openai_api_key! }
+          : embedding_provider === "ollama"
+            ? { provider: "ollama" }
+            : { provider: "local" };
+      const embedder = createEmbeddingProvider(embeddingConfig);
 
       const BATCH_SIZE = 50;
       const totalBatches = Math.ceil(allEvents.length / BATCH_SIZE);


### PR DESCRIPTION
## What

Adds the Ollama embedding provider (closes #6) and fixes the build which was broken due to `EmbeddingConfig` type mismatches after the provider was partially added.

## Changes

- **`src/lib/embeddings.ts`**: Add `OllamaEmbeddingProvider` class with batch support via `/api/embed`, `OllamaEmbeddingConfig` type, and `ollama` variant in the factory
- **`src/lib/timeline-db.ts`**: Update `TimelineConfig` to include `ollama` provider + config fields (`ollama_base_url`, `ollama_model`); fix caller to properly construct discriminated union
- **`src/tools/onboard-project.ts`**: Add `ollama` to `embedding_provider` enum; fix caller type construction

## Testing

- `npm run build` — clean ✅
- `npm test` — 43/43 passing ✅

Closes #6