### PR TITLE
Add annotated example .preflight/ config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,8 @@ This prevents the common failure mode: changing a shared type in one service and
 
 Drop this in your project root. Every field is optional — defaults are sensible.
 
+> **Quick start:** Copy the annotated examples from [`examples/.preflight/`](examples/.preflight/) into your project root and customize.
+
 ```yaml
 # Profile controls overall verbosity
 # "minimal" — only flag ambiguous+, skip clarification detail

--- a/examples/.preflight/config.yml
+++ b/examples/.preflight/config.yml
@@ -1,35 +1,34 @@
-# .preflight/config.yml — Drop this in your project root
+# .preflight/config.yml — copy this into your project root as .preflight/config.yml
 #
-# This is an example config for a typical Next.js + microservices setup.
-# Every field is optional — preflight works with sensible defaults out of the box.
-# Commit this to your repo so the whole team gets the same preflight behavior.
+# All fields are optional. Anything you omit uses the defaults shown below.
 
-# Profile controls how much detail preflight returns.
-#   "minimal"  — only flags ambiguous+ prompts, skips clarification detail
-#   "standard" — balanced (default)
-#   "full"     — maximum detail on every non-trivial prompt
+# Profile controls how aggressively preflight checks your prompts.
+#   minimal  — only catches extremely vague prompts
+#   standard — balanced (default)
+#   full     — checks everything, including commit messages and formatting tasks
 profile: standard
 
-# Related projects for cross-service awareness.
-# Preflight will search these for shared types, routes, and contracts
-# so it can warn you when a change might break a consumer.
+# Related projects for cross-service contract awareness.
+# Preflight indexes their types, interfaces, routes, and schemas so it can
+# warn you when a change in one project might break another.
 related_projects:
-  - path: /Users/you/code/auth-service
-    alias: auth
-  - path: /Users/you/code/billing-api
-    alias: billing
-  - path: /Users/you/code/shared-types
-    alias: types
+  - path: ../my-api
+    alias: api
+  - path: ../my-shared-lib
+    alias: shared
 
-# Behavioral thresholds — tune these to your workflow
+# Tuning knobs
 thresholds:
-  session_stale_minutes: 30                # Warn if no activity for this long
-  max_tool_calls_before_checkpoint: 100    # Suggest a checkpoint after N tool calls
-  correction_pattern_threshold: 3          # Min corrections before flagging a pattern
+  # Minutes before a session is considered stale (triggers re-onboarding hint)
+  session_stale_minutes: 30
+  # Tool calls before preflight suggests a checkpoint/commit
+  max_tool_calls_before_checkpoint: 100
+  # How many times a correction pattern must repeat before preflight warns
+  correction_pattern_threshold: 3
 
 # Embedding provider for semantic search over session history.
-# "local" uses Xenova transformers (no API key needed, runs on CPU).
-# "openai" uses text-embedding-3-small (faster, needs OPENAI_API_KEY).
+#   local  — runs Xenova/all-MiniLM-L6-v2 locally, no API key needed (~90 MB first download)
+#   openai — uses OpenAI text-embedding-3-small (needs OPENAI_API_KEY env var)
 embeddings:
   provider: local
-  # openai_api_key: sk-...               # Uncomment if using openai provider
+  # openai_api_key: sk-...  # or set OPENAI_API_KEY in your environment

--- a/examples/.preflight/triage.yml
+++ b/examples/.preflight/triage.yml
@@ -1,45 +1,39 @@
-# .preflight/triage.yml — Controls how preflight classifies your prompts
+# .preflight/triage.yml — triage rules for prompt classification
 #
-# The triage engine routes prompts into categories:
-#   TRIVIAL       → pass through (commit, format, lint)
-#   CLEAR         → well-specified, no intervention needed
-#   AMBIGUOUS     → needs clarification before proceeding
-#   MULTI-STEP    → complex task, preflight suggests a plan
-#   CROSS-SERVICE → touches multiple projects, pulls in contracts
-#
-# Customize the keywords below to match your domain.
+# Controls how the unified preflight_check tool classifies and routes prompts.
+# Copy this into your project's .preflight/ directory and customize.
+
+# How strict the triage engine is when deciding if a prompt needs intervention.
+#   relaxed  — only flags clearly ambiguous prompts
+#   standard — balanced (default)
+#   strict   — flags anything that could be more specific
+strictness: standard
 
 rules:
-  # Prompts containing these words are always flagged as AMBIGUOUS.
-  # Add domain-specific terms that tend to produce vague prompts.
+  # Keywords that ALWAYS trigger a full preflight check, even for short prompts.
+  # Use this for high-risk areas of your codebase.
   always_check:
     - rewards
     - permissions
     - migration
     - schema
-    - pricing          # example: your billing domain
-    - onboarding       # example: multi-step user flows
+    - billing
+    - auth
 
-  # Prompts containing these words skip checks entirely (TRIVIAL).
-  # These are safe, mechanical tasks that don't need guardrails.
+  # Keywords that SKIP preflight checks entirely.
+  # Use this for low-risk, mechanical tasks that don't need scrutiny.
   skip:
     - commit
     - format
     - lint
     - prettier
-    - "git push"
 
-  # Prompts containing these words trigger CROSS-SERVICE classification.
-  # Preflight will search related_projects for relevant types and routes.
+  # Keywords that trigger cross-service contract analysis.
+  # When these appear, preflight checks related projects for type/API mismatches.
   cross_service_keywords:
     - auth
     - notification
     - event
     - webhook
-    - billing          # matches the related_project alias
-
-# How aggressively to classify prompts.
-#   "relaxed"  — more prompts pass as clear (experienced users)
-#   "standard" — balanced (default)
-#   "strict"   — more prompts flagged as ambiguous (new teams, complex codebases)
-strictness: standard
+    - sync
+    - api


### PR DESCRIPTION
Users had to reverse-engineer the config format from source code or the inline README reference. This adds ready-to-copy `examples/.preflight/config.yml` and `examples/.preflight/triage.yml` with every option documented inline, plus a link from the Configuration Reference section.