### PR TITLE
fix: what_changed tool passes shell operators to execFileSync

### DIFF
--- a/src/tools/what-changed.ts
+++ b/src/tools/what-changed.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { run, getBranch, getDiffStat } from "../lib/git.js";
+import { run, getBranch, getDiffFiles, getDiffStat } from "../lib/git.js";
 
 export function registerWhatChanged(server: McpServer): void {
   server.tool(
@@ -12,13 +12,14 @@ export function registerWhatChanged(server: McpServer): void {
     async ({ since }) => {
       const ref = since || "HEAD~5";
       const diffStat = getDiffStat(ref);
-      const diffFiles = run(`git diff ${ref} --name-only 2>/dev/null || git diff HEAD~3 --name-only`);
-      const log = run(`git log ${ref}..HEAD --oneline 2>/dev/null || git log -5 --oneline`);
+      const diffFiles = getDiffFiles(ref);
+      const log = run(["log", `${ref}..HEAD`, "--oneline"]);
+      const commitLog = log.startsWith("[") ? run(["log", "-5", "--oneline"]) : log;
       const branch = getBranch();
 
       const fileList = diffFiles.split("\n").filter(Boolean);
       const fileCount = fileList.length;
-      const commitCount = log.split("\n").filter(Boolean).length;
+      const commitCount = commitLog.split("\n").filter(Boolean).length;
 
       return {
         content: [{
@@ -29,7 +30,7 @@ Branch: ${branch}
 
 ### Commits
 \`\`\`
-${log || "no commits in range"}
+${commitLog || "no commits in range"}
 \`\`\`
 
 ### Files Changed (${fileCount})


### PR DESCRIPTION
## Bug

`what_changed` was passing strings with shell operators (`2>/dev/null`, `||`) to `run()`, which uses `execFileSync` (no shell). The operators were being split on whitespace and passed as literal git arguments, producing wrong results or errors.

## Fix

- Use array-based `run()` calls instead of shell command strings
- Reuse existing `getDiffFiles()` helper which already handles fallback logic
- Add proper fallback for `git log` range queries

Build passes, all 43 tests green.