### PR TITLE
docs: add init wizard step to Quick Start, include examples/ in npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,20 @@ Add to your project's `.mcp.json`:
 
 Restart Claude Code. The tools activate automatically.
 
+### Optional: Initialize project config
+
+After adding the MCP server (any option), run the setup wizard in your project directory to create a `.preflight/` config:
+
+```bash
+# Interactive wizard — sets up .mcp.json and .preflight/ config
+npx preflight-dev
+
+# Or manually copy the example configs:
+cp -r node_modules/preflight-dev/examples/.preflight .preflight
+```
+
+The `.preflight/` directory is optional — preflight works with sensible defaults out of the box. But if you want to customize triage rules, add related projects for cross-service awareness, or tune thresholds, this is where you do it. Commit it to your repo so the whole team shares the same config.
+
 ### Option C: npm (global)
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "src/",
     "bin/",
     "dist/",
+    "examples/",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
- Added 'Optional: Initialize project config' section to Quick Start showing users how to run the setup wizard or manually copy example configs
- Added `examples/` to package.json `files` array so npm installs include the .preflight/ example configs
- The init wizard (`npx preflight-dev`) was only mentioned in a note under Option C — now it's a visible step for all install methods