### PR TITLE
fix(what-changed): use array args instead of shell syntax in run() calls

### DIFF
--- a/src/tools/what-changed.ts
+++ b/src/tools/what-changed.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { run, getBranch, getDiffStat } from "../lib/git.js";
+import { run, getBranch, getDiffFiles, getDiffStat } from "../lib/git.js";
 
 export function registerWhatChanged(server: McpServer): void {
   server.tool(
@@ -12,8 +12,9 @@ export function registerWhatChanged(server: McpServer): void {
     async ({ since }) => {
       const ref = since || "HEAD~5";
       const diffStat = getDiffStat(ref);
-      const diffFiles = run(`git diff ${ref} --name-only 2>/dev/null || git diff HEAD~3 --name-only`);
-      const log = run(`git log ${ref}..HEAD --oneline 2>/dev/null || git log -5 --oneline`);
+      const diffFiles = getDiffFiles(ref);
+      const logResult = run(["log", `${ref}..HEAD`, "--oneline"]);
+      const log = logResult.startsWith("[") ? run(["log", "-5", "--oneline"]) : logResult;
       const branch = getBranch();
 
       const fileList = diffFiles.split("\n").filter(Boolean);


### PR DESCRIPTION
## Problem

`what-changed.ts` was passing shell syntax (`2>/dev/null`, `||` operators) to `run()`, which uses `execFileSync` without a shell. These shell operators were passed as literal git arguments, causing silent failures.

## Fix

- Replace string-based `run()` calls with `getDiffFiles(ref)` helper (already has proper fallback logic)
- Replace `run(`git log ... || ...`)` with array args + explicit fallback check

Related: #302 (broader cleanup of shell syntax across all tools)