### PR TITLE
Add MCP Registry support (mcpName + server.json)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "preflight-dev",
+  "mcpName": "io.github.preflight-dev/preflight",
   "version": "3.2.0",
-  "description": "Preflight checks for AI coding agents — catch vague prompts, surface missing context, search session history",
+  "description": "Preflight checks for AI coding agents \u2014 catch vague prompts, surface missing context, search session history",
   "type": "module",
   "main": "dist/index.js",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.preflight-dev/preflight",
+  "description": "24-tool MCP server for Claude Code — catches vague prompts before they waste tokens, with 12-category scorecards, session history search via LanceDB vectors, cross-service contract awareness, correction pattern learning, and cost estimation.",
+  "repository": {
+    "url": "https://github.com/preflight-dev/preflight",
+    "source": "github"
+  },
+  "version": "3.2.0",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "preflight-dev",
+      "version": "3.2.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "description": "Path to the project directory for preflight to analyze",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false,
+          "name": "CLAUDE_PROJECT_DIR"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds the `mcpName` field to `package.json` and a `server.json` template for publishing preflight to the [official MCP Registry](https://registry.modelcontextprotocol.io).

## Why

The MCP Registry is the canonical directory that MCP clients (Claude Desktop, Cursor, etc.) pull from. Being listed there puts preflight in front of every developer browsing for MCP servers.

## After merging

Run the following to publish to the registry:

```bash
brew install mcp-publisher   # or curl install
mcp-publisher login github
mcp-publisher publish
```

See: https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/quickstart.mdx