### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ The pattern is always the same: vague prompt → Claude guesses → wrong output
 
 ---
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/preflight-dev-preflight).
+
 ## Quick Start
 
 ### Option A: npx (fastest — no install)


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/preflight-dev-preflight).